### PR TITLE
Modernized CMake and installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,9 @@ target_include_directories(rltk PUBLIC
 		)
 target_link_libraries(rltk PUBLIC ${ZLIB_LIBRARIES} ${SFML_LIBRARIES})
 if(NOT MSVC) # Why was this here? I exempted the wierd linker flags
-	target_compile_options(rltk "-O3 -Wall -Wpedantic -march=native -mtune=native -g")
+	target_compile_options(rltk PUBLIC -O3 -Wall -Wpedantic -march=native -mtune=native -g)
+else()
+	target_compile_options(rltk PUBLIC /W3 /EHsc)
 endif()
 
 install (TARGETS rltk
@@ -42,33 +44,33 @@ install (TARGETS rltk
 		RUNTIME DESTINATION bin)
 
 set(RLTK_HEADERS
-		astar.hpp
-		colors.hpp
-		color_t.hpp
-		ecs.hpp
-		ecs_impl.hpp
-		filesystem.hpp
-		font_manager.hpp
-		fsa.hpp
-		geometry.hpp
-		gui.hpp
-		gui_control_t.hpp
-		input_handler.hpp
-		layer_t.hpp
-		path_finding.hpp
-		perlin_noise.hpp
-		rexspeeder.hpp
-		rltk.hpp
-		rng.hpp
-		scaling.hpp
-		serialization_utils.hpp
-		texture.hpp
-		texture_resources.hpp
-		vchar.hpp
-		virtual_terminal.hpp
-		virtual_terminal_sparse.hpp
-		visibility.hpp
-		xml.hpp)
+		rltk/astar.hpp
+		rltk/colors.hpp
+		rltk/color_t.hpp
+		rltk/ecs.hpp
+		rltk/ecs_impl.hpp
+		rltk/filesystem.hpp
+		rltk/font_manager.hpp
+		rltk/fsa.hpp
+		rltk/geometry.hpp
+		rltk/gui.hpp
+		rltk/gui_control_t.hpp
+		rltk/input_handler.hpp
+		rltk/layer_t.hpp
+		rltk/path_finding.hpp
+		rltk/perlin_noise.hpp
+		rltk/rexspeeder.hpp
+		rltk/rltk.hpp
+		rltk/rng.hpp
+		rltk/scaling.hpp
+		rltk/serialization_utils.hpp
+		rltk/texture.hpp
+		rltk/texture_resources.hpp
+		rltk/vchar.hpp
+		rltk/virtual_terminal.hpp
+		rltk/virtual_terminal_sparse.hpp
+		rltk/visibility.hpp
+		rltk/xml.hpp)
 
 install(FILES ${RLTK_HEADERS}
 		DESTINATION "include/rltk"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,13 @@
 cmake_minimum_required(VERSION 3.1)
 project("rltk")
 
-set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake_modules)
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake_modules")
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED on)
-if(NOT(MSVC))
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -Wall -Wpedantic -march=native -mtune=native -g")
-	set(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -L/opt/local/lib -L/usr/lib/i386-linux-gnu")
-endif()
+
+find_package(ZLIB REQUIRED)
+find_package(SFML 2 COMPONENTS system window graphics REQUIRED)
+find_package(cereal REQUIRED)
 
 add_library(rltk 	rltk/rltk.cpp
 					rltk/texture_resources.cpp
@@ -25,16 +25,56 @@ add_library(rltk 	rltk/rltk.cpp
 					rltk/xml.cpp
 					rltk/perlin_noise.cpp
 					rltk/rexspeeder.cpp
-					rltk/scaling.cpp
-)
+					rltk/scaling.cpp)
+target_include_directories(rltk PUBLIC
+		"$<BUILD_INTERFACE:${SFML_INCLUDE_DIR}>"
+		"$<BUILD_INTERFACE:${CEREAL_INCLUDE_DIR}>"
+		"$<BUILD_INTERFACE:${ZLIB_INCLUDE_DIRS}>"
+		)
+target_link_libraries(rltk PUBLIC ${ZLIB_LIBRARIES} ${SFML_LIBRARIES})
+if(NOT MSVC) # Why was this here? I exempted the wierd linker flags
+	target_compile_options(rltk "-O3 -Wall -Wpedantic -march=native -mtune=native -g")
+endif()
 
-# Require SFML
-find_package(SFML 2 COMPONENTS system window graphics REQUIRED)
-include_directories(${SFML_INCLUDE_DIR})
+install (TARGETS rltk
+		ARCHIVE DESTINATION lib
+		LIBRARY DESTINATION lib
+		RUNTIME DESTINATION bin)
 
-# Cereal
-find_package(cereal REQUIRED)
-include_directories(${CEREAL_INCLUDE_DIR})
+set(RLTK_HEADERS
+		astar.hpp
+		colors.hpp
+		color_t.hpp
+		ecs.hpp
+		ecs_impl.hpp
+		filesystem.hpp
+		font_manager.hpp
+		fsa.hpp
+		geometry.hpp
+		gui.hpp
+		gui_control_t.hpp
+		input_handler.hpp
+		layer_t.hpp
+		path_finding.hpp
+		perlin_noise.hpp
+		rexspeeder.hpp
+		rltk.hpp
+		rng.hpp
+		scaling.hpp
+		serialization_utils.hpp
+		texture.hpp
+		texture_resources.hpp
+		vchar.hpp
+		virtual_terminal.hpp
+		virtual_terminal_sparse.hpp
+		visibility.hpp
+		xml.hpp)
+
+install(FILES ${RLTK_HEADERS}
+		DESTINATION "include/rltk"
+		)
+
+# Examples
 
 # Add all of the example executables and their library dependency
 add_executable(ex1 examples/ex1/main.cpp)
@@ -48,7 +88,6 @@ add_executable(ex8 examples/ex8/main.cpp)
 add_executable(ex9 examples/ex9/main.cpp)
 add_executable(ex10 examples/ex10/main.cpp)
 add_executable(ex11 examples/ex11/main.cpp)
-target_link_libraries(rltk ${SFML_LIBRARIES})
 target_link_libraries(ex1 rltk)
 target_link_libraries(ex2 rltk)
 target_link_libraries(ex3 rltk)
@@ -60,10 +99,3 @@ target_link_libraries(ex8 rltk)
 target_link_libraries(ex9 rltk)
 target_link_libraries(ex10 rltk)
 target_link_libraries(ex11 rltk)
-
-# We depend upon zlib
-find_package(ZLIB REQUIRED)
-if (ZLIB_FOUND)
-	include_directories(${ZLIB_INCLUDE_DIRS})
-	target_link_libraries(rltk ${ZLIB_LIBRARIES})
-endif()


### PR DESCRIPTION
This PR modernizes the CMakeLists.txt for proper isolated build flags and commands (no global CXX flags changes, etc). It also adds install targets, allow this to be built and installed as a proper library.

The changes should be pretty straight forward, and this was done to get it working in a more complex cmake build chain.


