### PR TITLE
Fixes destructors of base classes to be virtual

### DIFF
--- a/rltk/ecs_impl.hpp
+++ b/rltk/ecs_impl.hpp
@@ -172,6 +172,7 @@ namespace rltk {
          * Base class for the component store. Concrete component stores derive from this.
          */
         struct base_component_store {
+            virtual ~base_component_store() = default;
             virtual void erase_by_entity_id(ecs &ECS, const std::size_t &id)=0;
             virtual void really_delete()=0;
             virtual void save(xml_node * xml)=0;
@@ -256,6 +257,7 @@ namespace rltk {
          * Base class for storing subscriptions to messages
          */
         struct subscription_base_t {
+            virtual ~subscription_base_t() = default;
             virtual void deliver_messages()=0;
         };
 
@@ -389,6 +391,7 @@ namespace rltk {
      * Systems should inherit from this class.
      */
     struct base_system {
+        virtual ~base_system() = default;
         virtual void configure() {}
         virtual void update(const double duration_ms)=0;
         std::string system_name = "Unnamed System";

--- a/rltk/gui_control_t.hpp
+++ b/rltk/gui_control_t.hpp
@@ -20,6 +20,7 @@ namespace rltk {
  * Base type for retained-mode GUI controls.
  */
 struct gui_control_t {
+        virtual ~gui_control_t() = default;
 	virtual void render(virtual_terminal * console)=0;
 	virtual bool mouse_in_control(const int tx, const int ty) { return false; }
 


### PR DESCRIPTION
Destructors of base classes should be declared as virtual. This fixes a warning and potentially memory leaks.